### PR TITLE
fix: Mostrar el estado de seguimiento correcto en preview y resumen

### DIFF
--- a/app/components/custom/budgets/investments/info_component.html.erb
+++ b/app/components/custom/budgets/investments/info_component.html.erb
@@ -24,7 +24,7 @@
   <% if investment.milestone_status_id %>
     <div class="milestone">
       <span class="milestone-status">
-        <%= investment.milestone_status_id && Milestone.find(investment.milestone_status_id).status.name%>
+        <%= investment.milestone_status_id && Milestone::Status.find(investment.milestone_status_id).name%>
       </span>
     </div>
   <% end %>

--- a/app/views/custom/budgets/executions/_investments.html.erb
+++ b/app/views/custom/budgets/executions/_investments.html.erb
@@ -21,7 +21,7 @@
             <% if investment.milestone_status_id %>
                 <div class="milestone">
                     <span class="milestone-status">
-                      <%= Milestone.find(investment.milestone_status_id).status.name %>
+                      <%= Milestone::Status.find(investment.milestone_status_id).name %>
                     </span>
                   </div>
               <% end %>

--- a/spec/components/custom/budgets/investments/info_component_spec.rb
+++ b/spec/components/custom/budgets/investments/info_component_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+describe Budgets::Investments::InfoComponent do
+  it "renders the investment's own current milestone status, not another investment's" do
+    heading = create(:budget_heading)
+    status_a = create(:milestone_status, name: "Bidding")
+    status_b = create(:milestone_status, name: "Executing the project")
+
+    investment1 = create(:budget_investment, heading: heading, author_phone: "612345678")
+    investment2 = create(:budget_investment, heading: heading, author_phone: "612345678")
+    create(:milestone, milestoneable: investment1, status: status_b)
+    create(:milestone, milestoneable: investment2, status: status_a)
+
+    render_inline Budgets::Investments::InfoComponent.new(investment1)
+
+    expect(page).to have_content(status_b.name)
+    expect(page).not_to have_content(status_a.name)
+  end
+end

--- a/spec/system/custom/budgets/executions_spec.rb
+++ b/spec/system/custom/budgets/executions_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "Executions" do
+  let(:budget)  { create(:budget, :finished) }
+  let(:group)   { create(:budget_group, budget: budget) }
+  let(:heading) { create(:budget_heading, group: group) }
+  let(:phone)   { "612345678" }
+
+  let!(:investment1) { create(:budget_investment, :winner, heading: heading, author_phone: phone) }
+  let!(:investment2) { create(:budget_investment, :winner, heading: heading, author_phone: phone) }
+
+  context "Milestone status label" do
+    scenario "displays the investment's own current status, not another investment's" do
+      status_a = create(:milestone_status, name: "Bidding")
+      status_b = create(:milestone_status, name: "Executing the project")
+
+      create(:milestone, milestoneable: investment1, status: status_b)
+      create(:milestone, milestoneable: investment2, status: status_a)
+
+      visit budget_path(budget)
+      click_link "See results"
+      click_link "Milestones"
+
+      within(".budget-execution", text: investment1.title) do
+        expect(page).to have_content(status_b.name)
+        expect(page).not_to have_content(status_a.name)
+      end
+
+      within(".budget-execution", text: investment2.title) do
+        expect(page).to have_content(status_a.name)
+        expect(page).not_to have_content(status_b.name)
+      end
+    end
+  end
+end


### PR DESCRIPTION
investment.milestone_status_id devuelve el id de Milestone::Status, pero se usaba Milestone.find (tabla equivocada), lo que hacía que el preview mostrara el estado de un hito distinto en vez del actual.